### PR TITLE
fix: Switched from localstorage to sessionStorage to avoid data mix-u…

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -30,11 +30,11 @@ export default () => {
     })
 
     try {
-      if (localStorage.getItem('messageList'))
-        setMessageList(JSON.parse(localStorage.getItem('messageList')))
+      if (sessionStorage.getItem('messageList'))
+        setMessageList(JSON.parse(sessionStorage.getItem('messageList')))
 
-      if (localStorage.getItem('systemRoleSettings'))
-        setCurrentSystemRoleSettings(localStorage.getItem('systemRoleSettings'))
+      if (sessionStorage.getItem('systemRoleSettings'))
+        setCurrentSystemRoleSettings(sessionStorage.getItem('systemRoleSettings'))
 
       if (localStorage.getItem('stickToBottom') === 'stick')
         setStick(true)
@@ -49,8 +49,8 @@ export default () => {
   })
 
   const handleBeforeUnload = () => {
-    localStorage.setItem('messageList', JSON.stringify(messageList()))
-    localStorage.setItem('systemRoleSettings', currentSystemRoleSettings())
+    sessionStorage.setItem('messageList', JSON.stringify(messageList()))
+    sessionStorage.setItem('systemRoleSettings', currentSystemRoleSettings())
     isStick() ? localStorage.setItem('stickToBottom', 'stick') : localStorage.removeItem('stickToBottom')
   }
 


### PR DESCRIPTION
This pull request addresses an issue where localStorage is shared across different tabs, resulting in incorrect data being displayed in the Storage when multiple questions are asked by colleagues. Additionally, every time a new tab is opened, the existing data is displayed instead of allowing the user to ask new questions.

To resolve this issue, we have replaced localStorage with sessionStorage, which is not shared across tabs and allows for a more accurate representation of the data. With this change, users can now ask multiple questions without worrying about the data being mixed up or displayed incorrectly.
![企业微信截图_f30a1160-c099-4d2e-a299-5b4af9916312](https://github.com/anse-app/chatgpt-demo/assets/35401187/529f725d-5a88-4e3c-9a06-275d8b246fe3)
