### PR TITLE
fix deprecated keycode property

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -195,7 +195,7 @@ export default () => {
     if (e.isComposing || e.shiftKey)
       return
 
-    if (e.keyCode === 13) {
+    if (e.key === 'Enter') {
       e.preventDefault()
       handleButtonClick()
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode), we should most definitely not use the `keyCode` property. It is deprecated.

### Linked Issues

None.

### Additional context

Refer to the link https://www.w3.org/TR/uievents/#legacy-KeyboardEvent for further details.

<!-- e.g. is there anything you'd like reviewers to focus on? -->