### PR TITLE
feat: Display temperature value next to System Role

### DIFF
--- a/src/components/SystemRoleSettings.tsx
+++ b/src/components/SystemRoleSettings.tsx
@@ -35,7 +35,7 @@ export default (props: Props) => {
               <Show when={props.canEdit()} fallback={<IconEnv />}>
                 <span onClick={() => props.setCurrentSystemRoleSettings('')} class="sys-edit-btn p-1 rd-50%" > <IconX /> </span>
               </Show>
-              <span>System Role: </span>
+              <span>System Role ( Temp = {temperature()} ) : </span>
             </div>
             <div class="mt-1">
               {props.currentSystemRoleSettings()}


### PR DESCRIPTION
### Description

Display temperature value next to System Role.

### Demo

The Demo is the Chinese version of chatgpt-demo deployed for relatives and friends, but the effect is similar.
<img width="1277" alt="截屏2023-09-13 20 19 39" src="https://github.com/anse-app/chatgpt-demo/assets/37926645/167260f2-8ba9-451e-8ab0-9b26460f1575">
