### PR TITLE
fix: Set the max history messages to 9

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ PUBLIC_SECRET_KEY=
 SITE_PASSWORD=
 # ID of the model to use. https://platform.openai.com/docs/api-reference/models/list
 OPENAI_API_MODEL=
+# Set the maximum number of historical messages used for contextual contact
+PUBLIC_MAX_HISTORY_MESSAGES=

--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -19,7 +19,7 @@ export default () => {
   const [isStick, setStick] = createSignal(false)
   const [temperature, setTemperature] = createSignal(0.6);
   const temperatureSetting = (value: number) => { setTemperature(value) }
-  const maxHistoryMessages = parseInt(import.meta.env.PUBLIC_MAX_HISTORY_MESSAGES || '10')
+  const maxHistoryMessages = parseInt(import.meta.env.PUBLIC_MAX_HISTORY_MESSAGES || '9')
 
   createEffect(() => (isStick() && smoothToBottom()))
 

--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -19,6 +19,7 @@ export default () => {
   const [isStick, setStick] = createSignal(false)
   const [temperature, setTemperature] = createSignal(0.6);
   const temperatureSetting = (value: number) => { setTemperature(value) }
+  const maxHistoryMessages = parseInt(import.meta.env.PUBLIC_MAX_HISTORY_MESSAGES || '10')
 
   createEffect(() => (isStick() && smoothToBottom()))
 
@@ -89,7 +90,7 @@ export default () => {
     try {
       const controller = new AbortController()
       setController(controller)
-      const requestMessageList = [...messageList()]
+      const requestMessageList = messageList().slice(-maxHistoryMessages)
       if (currentSystemRoleSettings()) {
         requestMessageList.unshift({
           role: 'system',

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -8,6 +8,7 @@ interface ImportMetaEnv {
   readonly PUBLIC_SECRET_KEY: string
   readonly SITE_PASSWORD: string
   readonly OPENAI_API_MODEL: string
+  readonly PUBLIC_MAX_HISTORY_MESSAGES: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
### Description

Set the default context to send only the latest 9 historical messages to avoid exceeding the tokens limit error after chatting for a period of time.

Change the maximum number of history messages by setting the environment variable `PUBLIC_MAX_HISTORY_MESSAGES` if needed.

> It's not recommended to set it too low, such as 2, as it can easily lead to AI making random mistakes, even if it is GPT-4.

### Linked Issues

#309 

### Additional context

`Anse` is a very useful application, but `ChatGPT-Demo` is more suitable for deployment to relatives and friends who don’t know much about software.

However, during the use of `ChatGPT-Demo`, when the chat goes on for a long time, the `context_length_exceeded` error will easily occur.

After studying the file code of `ChatGPT-Demo`, I found that when it sends a message to the OpenAI API, it will send all historical messages together. No wonder it exceeds the token limit after chatting for a period of time.

**This will also cause excessive consumption of tokens.**

Therefore, I think it might be appropriate to set a certain length limit on the context messages sent to the OpenAI API. This can ensure that the chat continues in most cases.

Even though the AI might become "forgetful," it would still provide a better experience than clearing all chat history and starting over.

I set the default context message count to 9, which allows the OpenAI API to receive the latest 4 complete question and answer exchanges, as well as the most recent question.