### PR TITLE
fix: replace '/' with '|' in docker-env-replace.sh

### DIFF
--- a/hack/docker-env-replace.sh
+++ b/hack/docker-env-replace.sh
@@ -16,13 +16,13 @@ site_password=$SITE_PASSWORD
 openai_api_model=$OPENAI_API_MODEL
 
 for file in $(find ./dist -type f -name "*.mjs"); do
-  sed "s/({}).OPENAI_API_KEY/\"$openai_api_key\"/g;
-  s/({}).HTTPS_PROXY/\"$https_proxy\"/g;
-  s/({}).OPENAI_API_BASE_URL/\"$openai_api_base_url\"/g;
-  s/({}).HEAD_SCRIPTS/\"$head_scripts\"/g;
-  s/({}).PUBLIC_SECRET_KEY/\"$public_secret_key\"/g;
-  s/({}).OPENAI_API_MODEL/\"$openai_api_model\"/g;
-  s/({}).SITE_PASSWORD/\"$site_password\"/g" $file > tmp
+  sed "s|({}).OPENAI_API_KEY|\"$openai_api_key\"|g;
+  s|({}).HTTPS_PROXY|\"$https_proxy\"|g;
+  s|({}).OPENAI_API_BASE_URL|\"$openai_api_base_url\"|g;
+  s|({}).HEAD_SCRIPTS|\"$head_scripts\"|g;
+  s|({}).PUBLIC_SECRET_KEY|\"$public_secret_key\"|g;
+  s|({}).OPENAI_API_MODEL|\"$openai_api_model\"|g;
+  s|({}).SITE_PASSWORD|\"$site_password\"|g" $file > tmp
   mv tmp $file
 done
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description

The sed commands in the script were encountering issues when trying to match and replace patterns containing '/' in the OPENAI_API_BASE_URL variable.
This caused unexpected behavior during script execution.

To resolve this, replaced occurrences of '/' with '|' in the codebase to ensure proper pattern matching by sed.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->